### PR TITLE
fix(dccd): clean up ChangeRecord list while iterating

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -115,7 +115,7 @@ class _ConstantWatchRecord extends WatchRecord {
   }
 
   check() {
-    return null;
+    return false;
   }
 
   remove() {

--- a/src/watch_record.js
+++ b/src/watch_record.js
@@ -111,8 +111,7 @@ export class _FieldHandler extends _Handler {
   // This function forwards the watched object to the next [_Handler] synchronously
   acceptValue(object) {
     this.watchRecord.object = object;
-    var changeRecord = this.watchRecord.check();
-    if (changeRecord !== null) this.onChange(changeRecord);
+    if (this.watchRecord.check()) this.onChange(this.watchRecord);
   }
 }
 
@@ -124,8 +123,7 @@ export class _CollectionHandler extends _Handler {
   // This function forwards the watched object to the next [_Handler] synchronously
   acceptValue(object) {
     this.watchRecord.object = object;
-    var changeRecord = this.watchRecord.check();
-    if (changeRecord !== null) this.onChange(changeRecord);
+    if (this.watchRecord.check()) this.onChange(this.watchRecord);
   }
 
   _releaseWatch() {
@@ -270,9 +268,9 @@ export class _EvalWatchRecord {
     switch (this.mode) {
     case _MODE_MARKER_:
     case _MODE_NULL_:
-      return null;
+      return false;
     case _MODE_FUNCTION_:
-      if (!this.dirtyArgs) return null;
+      if (!this.dirtyArgs) return false;
       value = this.fn.apply(null, this.args);
       this.dirtyArgs = false;
       break;
@@ -291,10 +289,10 @@ export class _EvalWatchRecord {
         this.previousValue = current;
         this.currentValue = value;
         this.handler.onChange(this);
-        return this;
+        return true;
       }
     }
-    return null;
+    return false;
   }
 
   get nextChange() {

--- a/test/matchers.js
+++ b/test/matchers.js
@@ -73,15 +73,15 @@ beforeEach(function() {
     toEqualChanges: function(expected) {
       var count = 0;
       var actual = this.actual, changes = actual;
-      while(changes !== null) {
-        if (changes.handler !== expected[count++]) return false;
-        changes = changes.nextChange;
+      while(changes.iterate()) {
+        var current = changes.current;
+        if (current.handler !== expected[count++]) return false;
       }
       this.message = function() {
         var changes = actual, list = [];
-        while (changes !== null) {
-          list.push(changes.handler);
-          changes = changes.nextChange;
+        while (changes.iterate()) {
+          var current = changes.current;
+          list.push(current.handler);
         }
         return `expected changes [${list.join(', ')}] to equal [${expected.join(', ')}]`;
       }


### PR DESCRIPTION
https://github.com/angular/angular.dart/commit/75fbded7ad2691eb4391c56a595ab488842a85ed
fixes this issue in Angular.dart, in which deleted change groups could be kept
alive for long periods of time due to a live group retaining a pointer to it.

This results in an API change, in which the ChangeRecord linked list returned
by collectChanges() becomes an instance of a special iterator class, which
cleans up the list as it iterates.

This API is sort of a mess, and unfortunately won't make sense from a
usability perspective until ES6 is implemented natively. However, for the time
being, it is not unreasonable.

Closes #1
