### PR TITLE
test(karma): make debug tests work again

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -43,6 +43,7 @@ gulp.task('test', function(done) {
   };
   for (var i=0, ii = process.argv.length; i<ii; ++i) {
     var val = process.argv[i];
+    if (val === '--debug') options.debugRun = true;
     if (val === '--watch') options.autoWatch = true;
     else if (val === '--single-run') options.singleRun = true;
     else if (val === '--browsers') options.browsers = process.argv[++i].split(',');

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -37,6 +37,7 @@ module.exports = function(config) {
       array.splice(index, 1);
     }
   }
+
   if (process.argv.indexOf('--debug') >= 0) {
     arrayRemove(config.reporters, 'coverage');
     for (var key in config.preprocessors) {

--- a/lib/gulp/karma/background.js
+++ b/lib/gulp/karma/background.js
@@ -1,3 +1,8 @@
 var server = require('karma').server;
 var data = JSON.parse(process.argv[2]);
+var client = data.client || (data.client = {});
+var clientArgs = client.args || (client.args = []);
+
+if (process.argv.indexOf("--debug") >= 0) clientArgs.push("--debug");
+
 server.start(data);

--- a/lib/gulp/karma/index.js
+++ b/lib/gulp/karma/index.js
@@ -12,9 +12,13 @@ module.exports = exports = function karma(options, done) {
   if (typeof options.singleRun === 'undefined' && typeof options.autoWatch === 'undefined')
     options.singleRun = true;
   if (typeof options.browsers === 'string') options.browsers = [options.browsers];
-
+  var args = [path.join(__dirname, 'background.js'), JSON.stringify(options)];
+  if (!!options.debugRun) {
+    args.push('--debug');
+    delete options.debugRun;
+  }
   var proc = spawn(process.execPath,
-    [path.join(__dirname, 'background.js'), JSON.stringify(options)], {
+    args, {
       stdio: 'pipe',
       env: process.env
     });


### PR DESCRIPTION
This broke somehow, previously, but it has been corrected. It's a bit of a
hack, but the --debug flag gets passed to karma.conf.js correctly now.
