### PR TITLE
feat(watchgroup): improve method invokation, support methods of primitive types

### DIFF
--- a/src/watch_record.js
+++ b/src/watch_record.js
@@ -251,10 +251,7 @@ export class _EvalWatchRecord {
       if (haveMap && (value instanceof Map || value instanceof WeakMap)) {
         this.mode = _MODE_MAP_CLOSURE_;
       } else if (this.name) {
-        var descriptor = Object.getPropertyDescriptor(value, this.name);
-        if (typeof descriptor.value === "function") {
-          this.mode = _MODE_METHOD_;
-        }
+        this.mode = _MODE_METHOD_;
       }
     }
     /**
@@ -286,8 +283,7 @@ export class _EvalWatchRecord {
       this.dirtyArgs = false;
       break;
     case _MODE_METHOD_:
-      if (!this.dirtyArgs) return false;
-      value = this._object[this.name].apply(this._object, this.args);
+      value = methodInvoke(this._object, this.name, this.args);
       break;
     // TODO: the rest of these items don't really make sense in JS, as far as I can tell.
     // Investigate and ask about this.
@@ -333,4 +329,13 @@ export class _EvalWatchRecord {
   // static _hasMethod(mirror, symbol) {
   //   return mirror.type.instanceMembers[symbol] is MethodMirror;
   // }
+}
+
+var __no_args__ = [];
+function methodInvoke(object, method, args) {
+  if (object || object === 0 || object === false) {
+    if (typeof object[method] === "function") {
+      return object[method].apply(object, args || __no_args__);
+    }
+  }
 }

--- a/test/watchgroup.spec.js
+++ b/test/watchgroup.spec.js
@@ -439,6 +439,38 @@ describe('WatchGroup', function() {
       });
     }
 
+
+    it('should call methods of string primitives', function() {
+      setup({'text': 'abc'});
+      var ast = new MethodAST(parse('text'), 'toUpperCase', []);
+      watchGrp.watch(ast, logCurrentValue);
+      watchGrp.detectChanges();
+      expect(`${logger}`).toBe('ABC');
+    });
+
+
+    it('should call methods of number primitives', function() {
+      setup({num: 1.46483});
+      var ast = new MethodAST(parse('num'), 'toFixed', []);
+      watchGrp.watch(ast, logCurrentValue);
+      watchGrp.detectChanges();
+      expect(`${logger}`).toBe('1');
+    });
+
+
+    it('should not eval a function if registered during reaction', function() {
+      setup({'text': 'abc'});
+      var ast = new MethodAST(parse('text'), 'toLowerCase', []);
+      var watch = watchGrp.watch(ast, function(v, p) {
+        var ast = new MethodAST(parse('text'), 'toUpperCase', []);
+        watchGrp.watch(ast, logCurrentValue);
+      });
+
+      watchGrp.detectChanges();
+      watchGrp.detectChanges();
+      expect(`${logger}`).toBe('ABC');
+    });
+
     it('should not call functions or reacitons when registering method watches', function() {
       setupRegisterDuringReaction();
       expect(`${logger}`).toBe('');


### PR DESCRIPTION
Previously, properties were determined to be methods using awkward introspection techniques, and this caused problems for methods of primitive types. With this CL, method invokation no longer depends on using `Object#getPropertyDescriptor()`, and is capable of calling methods of string, number, boolean, and other types, in a much simpler fashion.

Closes #14
