### PR TITLE
chore(npmignore): add npmignore so that gitignore is not used

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,12 @@
+/test
+*.sublime-project
+*.sublime-workspace
+gulpfile.js
+karma.conf.js
+.travis.yml
+test-main.js
+.npmignore
+*.orig
+Gruntfile.*
+compiled/
+/coverage


### PR DESCRIPTION
.gitignore overrides .npmignore when .npmignore is not present, and this was
causing test failures on expressionist.js due to the `dist` directory not
being present.
