### PR TITLE
fix(watchgroup): also support method invocation on the empty string

### DIFF
--- a/src/watch_record.js
+++ b/src/watch_record.js
@@ -333,7 +333,7 @@ export class _EvalWatchRecord {
 
 var __no_args__ = [];
 function methodInvoke(object, method, args) {
-  if (object || object === 0 || object === false) {
+  if (object || (typeof object !== 'undefined' && object !== null)) {
     if (typeof object[method] === "function") {
       return object[method].apply(object, args || __no_args__);
     }

--- a/test/watchgroup.spec.js
+++ b/test/watchgroup.spec.js
@@ -449,6 +449,36 @@ describe('WatchGroup', function() {
     });
 
 
+    it('should support calling methods on the empty string', function() {
+      setup({'text': ''});
+      var reaction = jasmine.createSpy('reaction');
+      var ast = new MethodAST(parse('text'), 'toUpperCase', []);
+      watchGrp.watch(ast, reaction);
+      watchGrp.detectChanges();
+      expect(reaction).toHaveBeenCalledWith('', undefined);
+    });
+
+
+    it('should support calling methods on the number 0', function() {
+      setup({'num': 0});
+      var reaction = jasmine.createSpy('reaction');
+      var ast = new MethodAST(parse('num'), 'toFixed', []);
+      watchGrp.watch(ast, reaction);
+      watchGrp.detectChanges();
+      expect(reaction).toHaveBeenCalledWith('0', undefined);
+    });
+
+
+    it('should support calling methods on boolean false', function() {
+      setup({'boolean': false});
+      var reaction = jasmine.createSpy('reaction');
+      var ast = new MethodAST(parse('boolean'), 'valueOf', []);
+      watchGrp.watch(ast, reaction);
+      watchGrp.detectChanges();
+      expect(reaction).toHaveBeenCalledWith(false, undefined);
+    });
+
+
     it('should call methods of number primitives', function() {
       setup({num: 1.46483});
       var ast = new MethodAST(parse('num'), 'toFixed', []);


### PR DESCRIPTION
0965401fa009718e8f4aabda4f279884efaec646 added support for method invocation
on primitive types, however the empty string is treated as a null value, and
is neglected. While there is no good reason to call a method on the empty
string, it is now possible.
