### PR TITLE
fix(dirtychecking): prevent long prototype chain lookups of object properties

### DIFF
--- a/src/dirty_checking.js
+++ b/src/dirty_checking.js
@@ -334,6 +334,17 @@ class DirtyCheckingRecord extends ChangeRecord {
     }
     if (typeof obj === "object") {
       this._mode = _MODE_MAP_FIELD_;
+
+      if (obj && this._field !== null) {
+        var object = obj, field = this._field;
+        while (object && !object.hasOwnProperty(field)) {
+          object = Object.getPrototypeOf(object);
+        }
+        if (!object) {
+          throw new Error("property '" + field + "' not found in object");
+        }
+      }
+
       // _instanceMirror = null; --- Reflection needed?
     } else if (this._getter !== null) {
       this._mode = _MODE_GETTER_;


### PR DESCRIPTION
This doesn't really make a lot of sense, and is probably not worth doing. It 
also breaks tests, which will possibly be rectified after reviewing
angular.dart commit e12e5b52b7441436858628e7b9d9e98b6c9f518f.

Don't merge this! WIP

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/watchtower.js/24)

<!-- Reviewable:end -->
