### PR TITLE
style(watchtower): use template literals rather than explicit string operations

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "rtts-assert": "angular/assert",
     "gulp": "~3.5.2",
     "gulp-traceur": "vojtajina/gulp-traceur#traceur-as-peer",
-    "gulp-jshint": "~1.5.0",
+    "gulp-jshint": "~1.5.3",
     "jshint-stylish": "~0.1.5",
     "karma": "^0.12.1",
     "karma-script-launcher": "~0.1.0",

--- a/src/ast.js
+++ b/src/ast.js
@@ -49,7 +49,7 @@ export class ConstantAST extends AST {
   constructor(constant, expression) {
     if (arguments.length < 2) expression = null;
     super(expression === null
-        ? (typeof constant === "string" ? '"' + constant + '"' : '' + constant)
+        ? (typeof constant === "string" ? `"${constant}"` : `${constant}`)
         : expression);
     this.constant = constant;
   }
@@ -63,7 +63,7 @@ export class FieldReadAST extends AST {
   constructor(lhs, name) {
     this.lhs = lhs;
     this.name = name;
-    super(this.lhs + '.' + this.name);
+    super(`${lhs}.${name}`);
   }
 
   setupWatch(group) {
@@ -76,7 +76,7 @@ export class PureFunctionAST extends AST {
     this.fn = fn;
     this.argsAST = argsAST;
     this.name = name;
-    super(name + '(' + _argsList(argsAST) + ')');
+    super(`${name}(${_argsList(argsAST)})`);
   }
 
   setupWatch(group) {
@@ -89,7 +89,7 @@ export class MethodAST extends AST {
     this.lhsAST = lhsAST;
     this.name = name;
     this.argsAST = argsAST;
-    super(lhsAST + '.' + name + '(' + _argsList(argsAST) + ')');
+    super(`${lhsAST}.${name}(${_argsList(argsAST)})`);
   }
 
   setupWatch(group) {
@@ -100,7 +100,7 @@ export class MethodAST extends AST {
 export class CollectionAST extends AST {
   constructor(valueAST) {
     this.valueAST = valueAST;
-    super('#collection(' + valueAST + ')');
+    super(`#collection(${valueAST})`);
   }
 
   setupWatch(group) {

--- a/src/dirty_checking.js
+++ b/src/dirty_checking.js
@@ -398,7 +398,7 @@ class DirtyCheckingRecord extends ChangeRecord {
   toString() {
     // Where the heck is hashCode from?
     var hashCode = 0;
-    return _MODE_NAMES[this._mode] + '[' + this.field + ']{' + hashCode + '}';
+    return `${_MODE_NAMES[this._mode]}[${this.field}]{${hashCode}}`;
   }
 }
 class _MapChangeRecord extends MapChangeRecord {
@@ -661,7 +661,7 @@ class KeyValueRecord extends MapKeyValue {
   toString() {
     return this._previousValue === this._currentValue
           ? this._key
-          : this._key + '[' + this._previousValue + ' -> ' + this._currentValue + ']';
+          : `${this._key}[${this._previousValue} -> ${this._currentValue}]`;
   }
 }
 class _CollectionChangeRecord extends CollectionChangeRecord {
@@ -1072,8 +1072,8 @@ class ItemRecord extends CollectionChangeItem {
   }
   toString() {
     return this.previousIndex === this.currentIndex
-      ? '' + this.item
-      : this.item + '[' + this.previousIndex + ' -> ' + this.currentIndex + ']';
+      ? `${this.item}`
+      : `${this.item}[${this.previousIndex} -> ${this.currentIndex}]`;
   }
 }
 class _DuplicateItemRecordList {

--- a/src/watch_group.js
+++ b/src/watch_group.js
@@ -41,7 +41,7 @@ export class WatchGroup {
     // Initialize _WatchGroupList
     this._watchGroupHead = this._watchGroupTail = null;
     this._nextWatchGroup = this._prevWatchGroup = null;
-    this.id = parentWatchGroup.id + '.' + parentWatchGroup._nextChildId++;
+    this.id = `${parentWatchGroup.id}.${parentWatchGroup._nextChildId++}`;
     this._changeDetector = changeDetector;
     this.context = context;
     this._cache = cache;
@@ -220,10 +220,10 @@ export class WatchGroup {
     }
     watches.push(watch.toString());
 
-    lines.push('WatchGroup[' + this.id + '](watches: ' + watches.join(', ') + ')');
+    lines.push(`WatchGroup[${this.id}](watches: ${watches.join(', ')})`);
     var childGroup = this._watchGroupHead;
     while (childGroup !== null) {
-      lines.push('  ' + childGroup.toString().split('\n').join('\n  '));
+      lines.push(`  ${childGroup.toString().split('\n').join('\n  ')}`);
       childGroup = childGroup._nextWatchGroup;
     }
     return lines.join("\n");

--- a/src/watch_record.js
+++ b/src/watch_record.js
@@ -137,7 +137,7 @@ export class _CollectionHandler extends _Handler {
 export class _ArgHandler extends _Handler {
   constructor(watchGroup, watchRecord, index) {
     // TODO(caitp): assert that watchRecord is an _EvalWatchRecord?
-    super(watchGroup, 'arg[' + index + ']');
+    super(watchGroup, `arg[${index}]`);
     this._previousArgHandler = this._nextArgHandler = null;
     this.watchRecord = watchRecord;
     this.index = index;
@@ -321,8 +321,8 @@ export class _EvalWatchRecord {
   }
 
   toString() {
-    if (this.mode === _MODE_MARKER_) return 'MARKER[' + this.currentValue + ']';
-    return '' + this.watchGrp.id + ':' + this.handler.expression;
+    if (this.mode === _MODE_MARKER_) return `MARKER[${this.currentValue}]`;
+    return `${this.watchGrp.id}:${this.handler.expression}`;
   }
 
   // TODO(caitp): worry about this later...


### PR DESCRIPTION
Template literals are nice to look at, and jshint won't yell at us for using them,
anymore.

Closes #26
