### PR TITLE
fix(dirtychecking): don't throw when watching a child of an initially undefined property

### DIFF
--- a/src/dirty_checking.js
+++ b/src/dirty_checking.js
@@ -353,12 +353,14 @@ class DirtyCheckingRecord extends ChangeRecord {
         // I'm not sure how much support for Reflection is available in Traceur
         // just yet, but I will look into this later...
         // current = _instanceMirror.getField(_symbol).reflectee;
+        if (!this.object) return undefined;
         current = this.object[this.field];
         break;
       case _MODE_GETTER_:
         current = this._getter(this.object);
         break;
       case _MODE_MAP_FIELD_:
+        if (!this.object) return undefined;
         current = this.object[this.field];
         break;
       case _MODE_IDENTITY_:

--- a/test/watchgroup.spec.js
+++ b/test/watchgroup.spec.js
@@ -540,6 +540,30 @@ describe('WatchGroup', function() {
     });
 
 
+    it('should not throw watching child property of undefined', function() {
+      setup({});
+      expect(function() {
+        watchGrp.watch(parse('a.b'), logCurrentValue);
+        watchGrp.detectChanges();
+      }).not.toThrow();
+    });
+
+
+    it('should evaluate listener when child of previously undefined object changes', function() {
+      setup({});
+      watchGrp.watch(parse('a.b'), logCurrentValue);
+      watchGrp.detectChanges();
+
+      context.a = {};
+      context.a.b = "Hello";
+      watchGrp.detectChanges();
+      context.a.b = "World";
+      watchGrp.detectChanges();
+
+      expect(`${logger}`).toBe(";Hello;World");
+    });
+
+
     describe('filters', function() {
       function filter(name, fn, args) {
         if (!args[0].__filter__) args[0] = new CollectionAST(args[0]);


### PR DESCRIPTION
Closes #29
