### PR TITLE
feat(watch_group): split group manipulation into newGroup and addGroup

### DIFF
--- a/test/dirtychecking.spec.js
+++ b/test/dirtychecking.spec.js
@@ -132,9 +132,9 @@ describe('DirtyCheckingChangeDetector', function() {
       setup();
       var obj = {};
       var ra = watchGrp.watchField(obj, 'a', '0a');
-      var child1a = watchGrp.newGroup();
-      var child1b = watchGrp.newGroup();
-      var child2 = child1a.newGroup();
+      var child1a = createAndAddGroup(watchGrp);
+      var child1b = createAndAddGroup(watchGrp);
+      var child2 = createAndAddGroup(child1a);
 
       child1a.watchField(obj, 'a', '1a');
       child1b.watchField(obj, 'a', '1b');
@@ -153,7 +153,7 @@ describe('DirtyCheckingChangeDetector', function() {
       setup();
       var obj = {};
       var ra = watchGrp.watchField(obj, 'a', 'a');
-      var child = watchGrp.newGroup();
+      var child = createAndAddGroup(watchGrp);
       var cb = child.watchField(obj, 'b', 'b');
 
       obj['a'] = obj['b'] = 1;
@@ -177,9 +177,9 @@ describe('DirtyCheckingChangeDetector', function() {
 
     it('should properly add children', function() {
       setup();
-      var a = watchGrp.newGroup();
-      var aChild = a.newGroup();
-      var b = watchGrp.newGroup();
+      var a = createAndAddGroup(watchGrp);
+      var aChild = createAndAddGroup(a);
+      var b = createAndAddGroup(watchGrp);
       expect(function() {
         watchGrp.collectChanges();
       }).not.toThrow();
@@ -580,3 +580,10 @@ class _User {
     this.age = age;
   }
 }
+
+function createAndAddGroup(parentGroup, context){
+  var childGroup = parentGroup.newGroup(context);
+  parentGroup.addGroup(childGroup);
+  return childGroup;
+}
+

--- a/test/observer.spec.js
+++ b/test/observer.spec.js
@@ -123,7 +123,7 @@ describe('observer', function() {
           group;
 
       setup(observer);
-      group = watchGrp.newGroup();
+      group = createAndAddGroup(watchGrp);
       group.watchField(user, 'name', null);
 
       expect(observer.closeCalls).toBe(0);
@@ -183,3 +183,10 @@ class ExplicitObserver{
     this.callback = null;
   }
 }
+
+function createAndAddGroup(parentGroup, context){
+  var childGroup = parentGroup.newGroup(context);
+  parentGroup.addGroup(childGroup);
+  return childGroup;
+}
+


### PR DESCRIPTION
Previously, creating a new watch group simultaneously attached it to the
parent from which it was created. Now, we have split this behavior into two
steps so that it is possible to create a watch group, set up watches and then
choose which parent to attach it to at a later point in time. You can also
remove a watch group and attach it to a different parent. These features allow
a more elegant mechanism for turning watches on/off based on whether or not
the associated view is attached to the DOM. A primary use case for this is to
tie into the attachedCallback/detachedCallback of the custom element lifecycle
in order to better manage databinding present in element templates.

Closes issue #32
