### PR TITLE
chore(dirtychecking): remove `hashCode` references

### DIFF
--- a/src/dirty_checking.js
+++ b/src/dirty_checking.js
@@ -199,9 +199,7 @@ export class ChangeRecord {
   }
 
   toString() {
-    // Where the heck is hashCode from?
-    var hashCode = 0;
-    return `${_MODE_NAMES[this._mode]}[${this.field}]{${hashCode}}`;
+    return `${_MODE_NAMES[this._mode]}[${this.field}]`;
   }
 }
 


### PR DESCRIPTION
As Victor explained, and as I've verified in the dart tree, hashCodes have a
specified default implemenation in Dart which is not exposed in JS. While it
is possible to implement similar functionality, it's not clear that there's
any real benefit to it, so it is simply removed for the time being.

At a later point when it becomes clear that toString needs to uniquely
identify objects, then we can look at implementing a suitable algorithm for
generating unique identifiers.
